### PR TITLE
Adding the ability to search for multiple ingredients

### DIFF
--- a/public/controllers/viewRecipesController.js
+++ b/public/controllers/viewRecipesController.js
@@ -52,7 +52,7 @@
 
 		function doSearch(){
 			var searchCriteria = {};
-			searchCriteria.ingredient = $scope.searchTerm;
+			searchCriteria.ingredients = $scope.searchTerm.split(',');
 			$scope.recipes = searchService.search(searchCriteria);
 		}
 

--- a/routes/search.js
+++ b/routes/search.js
@@ -11,8 +11,13 @@ router.post('/', function(req, res, next) {
 	if(req.body.category && req.body.category.length>0){
 		recipeSearch = recipeSearch.where('category').equals(new RegExp(req.body.category,"i"));
 	}
-	if(req.body.ingredient && req.body.ingredient.length >0){
-		recipeSearch = recipeSearch.where('ingredients.name').equals(new RegExp(req.body.ingredient,"i"));
+
+	if(req.body.ingredients && req.body.ingredients.length > 0){
+		req.body.ingredients.map(function (ingredient) {
+			recipeSearch = recipeSearch
+				.where('ingredients.name')
+				.equals(new RegExp(ingredient.trim(),"i"));
+		});
 	}
 
   recipeSearch.exec(function (err, recipes) {


### PR DESCRIPTION
Currently, a user can only search for one ingredient at a time.  This commit adds the ability for a user to search for multiple ingredients at once, using a comma to separate ingredients.

Closes #5.
